### PR TITLE
Local UIfix: ensure .env file is created if not found when saving API key

### DIFF
--- a/swarms/structs/ui/ui.py
+++ b/swarms/structs/ui/ui.py
@@ -1636,6 +1636,10 @@ def create_app():
 
                         # Save API key to .env
                         env_path = find_dotenv()
+                        if not env_path:
+                            env_path = os.path.join(os.getcwd(), ".env")
+                            with open(env_path, "w") as f:
+                                f.write("")
                         if provider == "openai":
                             set_key(env_path, "OPENAI_API_KEY", api_key)
                         elif provider == "anthropic":


### PR DESCRIPTION
This pull request includes a small but important change to the `swarms/structs/ui/ui.py` file. The change ensures that an `.env` file is created if it does not already exist when saving the API key.

* [`swarms/structs/ui/ui.py`](diffhunk://#diff-98d90565a78ffe8ea3b52b86c514f94ab29fff2f04c7f5fa838c6ee4f60c6ffbR1639-R1642): Added code to check if `.env` file exists and create it if not, ensuring the API key can be saved correctly.

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--3.org.readthedocs.build/en/3/

<!-- readthedocs-preview swarms end -->